### PR TITLE
Useful versions synchronization between plugin and SoapUI test runner release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath ("gradle.plugin.io.byteshifter:soapui-gradle-plugin:0.2") {
+    classpath ("gradle.plugin.io.byteshifter:soapui-gradle-plugin:5.0.1") {
         exclude module: 'cajo'
         exclude group: 'org.codehaus.groovy'
       }
@@ -219,6 +219,20 @@ task testSuiteB(type: TestTask) {
 }
 ```
 What you should notice in the example above is that we still use the `soapui` convention block with the nested `test` section. You may also have noticed that we have defined 2 new tasks of type `TestTask`. The `TestTask` is what runs the `SoapUITestCaseRunner`. The only difference between the 2 tasks is that they set their own value for `testSuite`. Through the magic of convention mapping the rest of the values are inherited.
+
+
+## SoapUI test runner and plugin versions mapping
+
+Previously, versions between soapui-gradle-plugin and SoapUI test runner was't synchronized.
+But from version 5.0.1 we will try to keep them synchronized as soon as newer SoapUI will be released.
+
+| soapui-gradle-plugin | SoapUI test runner |
+| -------------------- | ------------------ |
+| 0.2                  | 5.0.1              |
+| 5.0.1                | 5.0.1              |
+| .....                | .....              |
+| 5.3.0                | 5.3.0              |
+| 5.3.1-RC             | 5.3.1-RC           |
 
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath ("gradle.plugin.io.byteshifter:soapui-gradle-plugin:5.0.1") {
+    classpath ("gradle.plugin.io.byteshifter:soapui-gradle-plugin:5.1.0") {
         exclude module: 'cajo'
         exclude group: 'org.codehaus.groovy'
       }

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,9 @@
+buildscript {
+    ext {
+        soapUiVersion = '5.0.1'
+    }
+}
+
 plugins {
     id 'com.gradle.plugin-publish' version '0.9.1'
 }
@@ -10,7 +16,7 @@ apply from: "${rootDir}/gradle/license.gradle"
 
 description 'Gradle plugin for running SoapUI projects'
 group 'io.byteshifter'
-version = '0.2'
+version = "$soapUiVersion"
 
 targetCompatibility = 1.6
 sourceCompatibility = 1.6
@@ -32,7 +38,7 @@ dependencies {
     /**
      * SoapUI dependencies
      */
-    compile ('com.smartbear.soapui:soapui:5.0.1') {
+    compile ("com.smartbear.soapui:soapui:$soapUiVersion") {
         exclude module: 'cajo'
         exclude group: 'org.codehaus.groovy'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        soapUiVersion = '5.0.1'
+        soapUiVersion = '5.1.0'
     }
 }
 


### PR DESCRIPTION
Update plugin build for synchronization between versions of SoapUI test runner and soapui-gradle-plugin.

Each newer SoapUI release can be easily upgraded (if no jar-hell occurs) just with updating:
- soapUiVersion ext variable inside build.gradle
- plugin version inside README.md

For each published release it would be also good create a tag in case if any bugs where found.
Otherwise, it would be hard to maintain different versions.